### PR TITLE
Avoid data duplication for news

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -4,8 +4,9 @@ title: "ASA Biopharmaceutical Section Software Engineering Working Group"
 
 Welcome to the home page of the American Statistical Association (ASA) Biopharmaceutical Section (BIOP) Software Engineering Working Group (SWE WG). To learn more about the WG see [about us](goals.qmd).
 
-<img src = "sticker/sticker-1200.png" alt = "Hex Sticker for ASA BIOP SWE Working Group" width = "200">
+<img src="sticker/sticker-1200.png" alt="Hex Sticker for ASA BIOP SWE Working Group" width="200"/>
 
-**Latest Updates**
+**Latest Updates:**
 
-* **7 Oct 2022**: Initial publication of the website.
+```{r, child = "news.qmd"}
+```

--- a/news.qmd
+++ b/news.qmd
@@ -2,7 +2,7 @@
   title: "News"
 ---
 
+- **10 Oct 2022**: Added hex sticker for the working group. 
+  Credits to <a href="https://www.flaticon.com/free-icons/technology" title="technology icons">Kalashnyk</a> on Flaticon for creating the sticker icon.
 
--   **10 Oct 2022**: Added hex sticker for the working group. Credits to <a href="https://www.flaticon.com/free-icons/technology" title="technology icons">Kalashnyk</a> on Flaticon for creating the sticker icon.
-
--   **7 Oct 2022**: Initial publication of the website.
+- **7 Oct 2022**: Initial publication of the website.


### PR DESCRIPTION
This is a simple patch that fixes #6.

As of now, it just reads the content of `news.qmd` into `index.qmd`, which may not be optimal if we aim to have a _subset_ of news (say, latest 5 entries) in the homepage and the whole list in the news page.

To fix that we could have a `.csv` file (or something similar) with the news data, which is then read into each `.qmd` file, similarly to how group members data is currently handled.

Any thoughts on that?