### PR TITLE
Link to the {brms.mmrm} package

### DIFF
--- a/bayesian_mmrm_R_package.qmd
+++ b/bayesian_mmrm_R_package.qmd
@@ -11,3 +11,5 @@ path <- getwd()
 source(file = paste(path, "/utils/read_members.R", sep = ""))
 read.members("bayesian_mmrm")
 ```
+
+To learn more about our Bayesian MMRM R package using [`brms`](https://paul-buerkner.github.io/brms/), please visit [rconsortium.github.io/brms.mmrm/](https://rconsortium.github.io/brms.mmrm/).


### PR DESCRIPTION
This PR adds a link to the [`brms.mmrm`](https://rconsortium.github.io/brms.mmrm/) R package to the tail of `bayesian_mmrm_R_package.qmd`.