### PR TITLE
replace docker image with IE one to get Quarto 1.4

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Build & Deploy
     runs-on: ubuntu-latest
     container:
-      image: rocker/tidyverse:latest
+      image: ghcr.io/insightsengineering/rstudio:latest
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
this should fix the publishing of the Quarto website, in particular the hexwall