### PR TITLE
Comments in blog posts only

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -41,21 +41,6 @@ website:
       - icon: rss
         href: blog.xml
 
-  comments:
-    giscus:
-      # Reference: https://quarto.org/docs/reference/projects/books.html#giscus
-      # Also https://giscus.app/ for all options
-      repo: RConsortium/asa-biop-swe-wg
-      repo-id: "R_kgDOIEo72A"
-      category: "Ideas"
-      category-id: "DIC_kwDOIEo72M4CRqLG"
-      reactions-enabled: true
-      theme: light
-      language: en
-      loading: lazy
-      mapping: pathname
-      input-position: "top"
-
 format:
   html:
     toc: true

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -41,6 +41,22 @@ website:
       - icon: rss
         href: blog.xml
 
+  # Giscus comments:
+  comments:
+    giscus:
+      # Reference: https://quarto.org/docs/reference/projects/books.html#giscus
+      # Also https://giscus.app/ for all options
+      repo: RConsortium/asa-biop-swe-wg
+      repo-id: "R_kgDOIEo72A"
+      category: "Ideas"
+      category-id: "DIC_kwDOIEo72M4CRqLG"
+      reactions-enabled: true
+      theme: light
+      language: en
+      loading: lazy
+      mapping: pathname
+      input-position: "top"
+
 format:
   html:
     toc: true

--- a/blog/_metadata.yml
+++ b/blog/_metadata.yml
@@ -6,3 +6,19 @@ freeze: true
 
 # Enable banner style title blocks
 title-block-banner: true
+
+# Giscus comments:
+comments:
+  giscus:
+    # Reference: https://quarto.org/docs/reference/projects/books.html#giscus
+    # Also https://giscus.app/ for all options
+    repo: RConsortium/asa-biop-swe-wg
+    repo-id: "R_kgDOIEo72A"
+    category: "Ideas"
+    category-id: "DIC_kwDOIEo72M4CRqLG"
+    reactions-enabled: true
+    theme: light
+    language: en
+    loading: lazy
+    mapping: pathname
+    input-position: "top"

--- a/blog/_metadata.yml
+++ b/blog/_metadata.yml
@@ -6,19 +6,3 @@ freeze: true
 
 # Enable banner style title blocks
 title-block-banner: true
-
-# Giscus comments:
-comments:
-  giscus:
-    # Reference: https://quarto.org/docs/reference/projects/books.html#giscus
-    # Also https://giscus.app/ for all options
-    repo: RConsortium/asa-biop-swe-wg
-    repo-id: "R_kgDOIEo72A"
-    category: "Ideas"
-    category-id: "DIC_kwDOIEo72M4CRqLG"
-    reactions-enabled: true
-    theme: light
-    language: en
-    loading: lazy
-    mapping: pathname
-    input-position: "top"

--- a/index.qmd
+++ b/index.qmd
@@ -1,5 +1,6 @@
 ---
 pagetitle: "openstatsware"
+comments: false
 ---
 
 ```{=html}


### PR DESCRIPTION
Hi,

This PR moves the Giscus setup to `blog/_metadata.yaml`, thus enabling comments in blog posts only. The main idea was to remove it from the homepage, as I don't think it was very useful – what do you think? Should comments stay in other pages?

Alessandro
